### PR TITLE
docs: make (appropriate) code blocks clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ Please make sure that docker is installed on your machine! It's required to run 
 ### General Setup
 
 1. Create a 2A Management cluster with kind:
-    ```
+    ```shell
     make bootstrap-kind-cluster
     ```
     You could give it another name by specifying the `KIND_CLUSTER_NAME` environment variable.
 
 2. Install 2A into kind cluster:
-    ```
+    ```shell
     make deploy-2a
     ```
     The Demos in this repo require at least 2A v0.0.5 or newer. You can change the version of 2A by specifying the `HMC_VERSION` environment variable.
 
 3. Monitor the installation of 2A (you probably will need to install `jq` to execute this command):
-    ```
+    ```shell
     PATH=$PATH:./bin kubectl get management hmc -o json | jq -r '.status.components | to_entries[] | "\(.key): \(.value.success // .value.error)"'
     ```
    If the installation of 2a succeeded, the output should look as follows
@@ -44,7 +44,7 @@ Please make sure that docker is installed on your machine! It's required to run 
    ```
 
 4. Install the Demo Helm Repo into 2A:
-    ```
+    ```shell
     make setup-helmrepo
     ```
     This step adds a [`HelmRepository` resource](https://fluxcd.io/flux/components/source/helmrepositories/) to the cluster that contains Helm charts for this demo.
@@ -67,7 +67,7 @@ This assumes that you already have configured the required [AWS IAM Roles](https
     ````
 
 2. Install Credentials into 2A:
-    ```
+    ```shell
     make setup-aws-creds
     ```
 
@@ -77,7 +77,7 @@ If your plan is to demo an upgrade (Demo 2) or anything related to ServiceTempla
 
 
 1. Install templates and create aws-test1 cluster
-    ```
+    ```shell
     make install-clustertemplate-demo-aws-standalone-cp-0.0.1
     make apply-aws-test1-0.0.1
     make watch-aws-test1
@@ -88,18 +88,18 @@ If your plan is to demo an upgrade (Demo 2) or anything related to ServiceTempla
 If you plan to demo Demo 5 or above we need a secondary namespace (we call it blue in this demo) and credentials for a Platform Engineer that does only have access to the blue namespace and not cluster admin.
 
 1. Create target namespace blue and required rolebindings
-    ```
+    ```shell
     make create-target-namespace-rolebindings
     ```
 
 2. Generate Kubeconfig for platform engineer
-    ```
+    ```shell
     make clean-certs
     make generate-platform-engineer1-kubeconfig
     ```
 
 3. Test Kubeconfig
-    ```
+    ```shell
     KUBECONFIG="certs/platform-engineer1/kubeconfig.yaml" kubectl get ns blue
     ```
 
@@ -111,7 +111,7 @@ In the real world this would most probably be done by a Platform Team Lead that 
 
 
 1. Install ClusterTemplate in 2A
-    ```
+    ```shell
     make install-clustertemplate-demo-aws-standalone-cp-0.0.1
     ```
     This will install the custom ClusterTmplate and ClusterTemplateChain `demo-aws-standalone-cp-0.0.1` which exists in this Git Repo under `templates/cluster/demo-aws-standalone-cp-0.0.1` is hosted on the Github OCI registry at https://github.com/Mirantis/2a-demos.
@@ -123,7 +123,7 @@ In the real world this would most probably be done by a Platform Team Lead that 
     As assumed by 2A all ClusterTemplates will be installed first into the `hmc-system` Namespace and can there be used directly to create a Cluster:
 
 2. Install Test Clusters:
-    ```
+    ```shell
     make apply-aws-test1-0.0.1
     make apply-aws-test2-0.0.1
     ```
@@ -133,14 +133,14 @@ In the real world this would most probably be done by a Platform Team Lead that 
 
 
 3. Monitor the deployment of the Cluster:
-    ```
+    ```shell
     make watch-aws-test2
     ```
     This will show the status and rollout of the cluster as seen by 2A.
 
 
 4. Create Kubeconfig for Clusters:
-    ```
+    ```shell
     make get-kubeconfig-aws-test1
     make get-kubeconfig-aws-test2
     ````
@@ -148,11 +148,11 @@ In the real world this would most probably be done by a Platform Team Lead that 
 
 
 5. Access Clusters through kubectl
-    ```
+    ```shell
     KUBECONFIG="kubeconfigs/hmc-system-aws-test1.kubeconfig" kubectl get pods -A
     ```
 
-    ```
+    ```shell
     KUBECONFIG="kubeconfigs/hmc-system-aws-test2.kubeconfig" kubectl get pods -A
     ```
 
@@ -163,7 +163,7 @@ This demo shows how to upgrade an existing cluster through the cluster template 
 This demo will upgrade the k8s cluster from `v1.31.1+k0s.1` (which is part of the `demo-aws-standalone-cp-0.0.1` template) to `v1.31.2+k0s.0` (which is part of `demo-aws-standalone-cp-0.0.2`)
 
 1. Install ClusterTemplate Upgrade
-    ```
+    ```shell
     make install-clustertemplate-demo-aws-standalone-cp-0.0.2
     ```
     This will actually not only install a ClusterTemplate but also a ClusterTemplateChain. This ClusterTemplateChain will tell 2A that the `demo-aws-standalone-cp-0.0.2` is an upgrade from `demo-aws-standalone-cp-0.0.1`. You can see the source for it [here](templates/cluster/demo-aws-standalone-cp-0.0.2.yaml).
@@ -171,7 +171,7 @@ This demo will upgrade the k8s cluster from `v1.31.1+k0s.1` (which is part of th
 
 2. The fact that we have an upgrade available will be reported by 2A, and can be checked with:
 
-    ```
+    ```shell
     kubectl -n hmc-system get managedcluster.hmc.mirantis.com hmc-system-aws-test1 -o jsonpath='{.status.availableUpgrades}'
     ```
 
@@ -184,13 +184,13 @@ This demo will upgrade the k8s cluster from `v1.31.1+k0s.1` (which is part of th
     ```
 
 3. Apply Upgrade of the cluster:
-    ```
+    ```shell
     make apply-aws-test1-0.0.2
     ```
 
 
 4. Monitor the rollout of the upgrade
-   ```bash
+   ```shell
    KUBECONFIG="kubeconfigs/hmc-system-aws-test1.kubeconfig" kubectl get nodes --all-namespaces --watch
    ```
 
@@ -201,19 +201,19 @@ This demo shows how a ServiceTemplate can be installed in a Cluster.
 In order to run this demo you need `Demo 1` completed, which created the `aws-test2` cluster.
 
 1. Install ServiceTemplate in 2A:
-    ```
+    ```shell
     make install-servicetemplate-demo-ingress-nginx-4.11.0
     ```
 
 2. Apply ServiceTemplate to cluster:
-    ```
+    ```shell
     make apply-aws-test2-0.0.1-ingress
     ```
     This applies the [0.0.1-ingress.yaml](managedClusters/aws/0.0.1-ingress.yaml) yaml template. For simplicity the yamls are a full `ManagedCluster` Object and not just a diff from the original cluster. The command output will show you a diff that explains that the only thing that actually has changed is the `serviceTemplate` key
 
 
 3. Show that ingress-nginx is installed in the managed cluster:
-    ```
+    ```shell
     KUBECONFIG="kubeconfigs/hmc-system-aws-test2.kubeconfig" kubectl get pods -n ingress-nginx --watch
     ```
 
@@ -227,22 +227,22 @@ While this demo can be shown even if you only have a single cluster, its obvious
 Be aware though that the cluster creation takes around 10-15mins, so depending on how fast you give the demo, the cluster creation might not be completed and the installation of services possible also delayed. You can totally follow this demo and the services will be installed after the clusters are ready.
 
 1. Install Kyverno ServiceTemplate in 2A:
-    ```
+    ```shell
     make install-servicetemplate-demo-kyverno-3.2.6
     ```
     This will install a new servicetemplate which installs a standard installation of kyverno in a cluster. It has a clusterSelector configuration of the label `app.kubernetes.io/managed-by: Helm` which currently is the simplest way to match all clusters.
 
 2. Apply MultiClusterService to cluster:
-    ```
+    ```shell
     make apply-multiclusterservice-global-kyverno
     ```
 
 3. Show that kyverno is being installed in the two managed cluster:
-    ```
+    ```shell
     KUBECONFIG="kubeconfigs/hmc-system-aws-test1.kubeconfig" kubectl get pods -n kyverno
     ```
 
-    ```
+    ```shell
     KUBECONFIG="kubeconfigs/hmc-system-aws-test2.kubeconfig" kubectl get pods -n kyverno
     ```
 
@@ -251,17 +251,17 @@ Be aware though that the cluster creation takes around 10-15mins, so depending o
 ## Demo 5: Approve ClusterTemplate & InfraCredentials for separate Namespace
 
 1. Approve the clustertemplate into the blue namespace
-    ```
+    ```shell
     make approve-clustertemplatechain-aws-standalone-cp-0.0.1
     ```
 
 2. Approve the AWS credentials into the blue namspace
-    ```
+    ```shell
     make approve-credential-aws
     ```
 
 3. Show that the platform engineer only can see the approved clustertemplate and no other ones:
-    ```
+    ```shell
     KUBECONFIG="certs/platform-engineer1/kubeconfig.yaml" kubectl get clustertemplates -n blue
     ```
 
@@ -270,17 +270,17 @@ Be aware though that the cluster creation takes around 10-15mins, so depending o
 This demo is currently broken in HMC 0.0.5 until [#818](https://github.com/Mirantis/hmc/issues/818) is resolved.
 
 1. Create Cluster in blue namespace (this will be ran as platform engineer)
-    ```
+    ```shell
     make apply-aws-dev1-0.0.1
     ```
 
 2. Get Kubeconfig for `aws-dev1`
-    ```
+    ```shell
     make get-kubeconfig-aws-dev1
     ```
 
 3. Access cluster
-    ```
+    ```shell
     KUBECONFIG="kubeconfigs/blue-aws-dev1.kubeconfig" kubectl get pods -A
     ```
 


### PR DESCRIPTION
This PR makes code blocks clickable (if your markdown reader supports it). 

It could improve demos a bit.

Before:
<img width="787" alt="Screenshot 2024-12-20 at 08 27 54" src="https://github.com/user-attachments/assets/f6e66e53-c527-4eae-a08e-df78c39fe167" />

After:
<img width="826" alt="Screenshot 2024-12-20 at 08 29 48" src="https://github.com/user-attachments/assets/ecd08995-4963-476f-a874-01f9a2676bdd" />

