### PR TITLE
replaced go dependency with system envtest utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Please make sure that docker is installed on your machine! It's required to run 
 As next you need to decide into which infrastructure you would like to install the Demo clusters. This Demo Repo has support for the following Infra Providers (more to follow in the future):
 
 - AWS
-
+- Azure
 
 #### AWS Setup
 
@@ -70,6 +70,22 @@ This assumes that you already have configured the required [AWS IAM Roles](https
 2. Install Credentials into 2A:
     ```shell
     make setup-aws-creds
+    ```
+
+#### Azure Setup
+
+This assumes that you already have configured the required [Azure providers](https://mirantis.github.io/project-2a-docs/quick-start/azure/#register-resource-providers) and created a [Azure Service Principal](https://mirantis.github.io/project-2a-docs/quick-start/azure/#step-2-create-a-service-principal-sp).
+
+1. Export Azure Service Principal keys as environment variables:
+    ```
+    export AZURE_SP_PASSWORD=<Service Principal password>
+    export AZURE_SP_APP_ID=<Service Principal App ID>
+    export AZURE_SP_TENANT_ID=<Service Principal Tenant ID>
+    ```
+
+2. Install Credentials into 2A:
+    ```
+    make setup-azure-creds
     ```
 
 ### Demo Cluster Setup

--- a/setup/aws-credentials.yaml
+++ b/setup/aws-credentials.yaml
@@ -3,7 +3,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterStaticIdentity
 metadata:
   name: aws-cluster-identity
-  namespace: hmc-system
+  namespace: ${TESTING_NAMESPACE}
 spec:
   secretRef: aws-cluster-identity-secret
   allowedNamespaces:
@@ -14,7 +14,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: aws-cluster-identity-secret
-  namespace: hmc-system
+  namespace: ${TESTING_NAMESPACE}
 type: Opaque
 stringData:
   AccessKeyID: ${AWS_ACCESS_KEY_ID}
@@ -24,11 +24,11 @@ apiVersion: hmc.mirantis.com/v1alpha1
 kind: Credential
 metadata:
   name: aws-cluster-identity-cred
-  namespace: hmc-system
+  namespace: ${TESTING_NAMESPACE}
 spec:
   description: AWS credentials
   identityRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: AWSClusterStaticIdentity
     name: aws-cluster-identity
-    namespace: hmc-system
+    namespace: ${TESTING_NAMESPACE}

--- a/setup/azure-credentials.yaml
+++ b/setup/azure-credentials.yaml
@@ -5,34 +5,34 @@ metadata:
   labels:
     clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: azure-cluster-identity
-  namespace: hmc-system
+  namespace: ${TESTING_NAMESPACE}
 spec:
   allowedNamespaces: {}
-  clientID: "${AZURE_CLIENT_ID}"
+  clientID: ${AZURE_SP_APP_ID}
   clientSecret:
     name: azure-cluster-identity-secret
-    namespace: hmc-system
-  tenantID: "${AZURE_TENANT_ID}"
+    namespace: ${TESTING_NAMESPACE}
+  tenantID: ${AZURE_SP_TENANT_ID}
   type: ServicePrincipal
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: azure-cluster-identity-secret
-  namespace: hmc-system
+  namespace: ${TESTING_NAMESPACE}
 stringData:
-  clientSecret: "${AZURE_CLIENT_SECRET}"
+  clientSecret: ${AZURE_SP_PASSWORD}
 type: Opaque
 ---
 apiVersion: hmc.mirantis.com/v1alpha1
 kind: Credential
 metadata:
   name: azure-cluster-identity-cred
-  namespace: hmc-system
+  namespace: ${TESTING_NAMESPACE}
 spec:
   description: Azure credentials
   identityRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureClusterIdentity
     name: azure-cluster-identity
-    namespace: hmc-system
+    namespace: ${TESTING_NAMESPACE}


### PR DESCRIPTION
1. Replaced go envtest dependency with Unix system built-in envtest utility. Golang can be not present on local machines and it's not a good idea to force users to install it only for simple envtest binary installation. Unix default envtest utility does pretty same except it doesn't have options to fail on missing variables.
2. Added the default Makefile `.EXPORT_ALL_VARIABLES:` target that allows to use all Makefile variables as environment variables for script and target executions
3. Added AWS and Azure required environment variables checks before credentials creation. These checks print human readable information
4. Added Azure infra setup documentation to the README.md
5. Added Infra setup commands to the `make help` information
6. cleaned up namespace variables in Makefile targets

Tested on MacOS arm64 Sonoma 14.7 and Linux amd64 Ubuntu 22.04