### PR TITLE
Refactoring, improvements and bugfixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 # All Makefile variable are available as environment variables during target executions
 .EXPORT_ALL_VARIABLES:
 
@@ -7,19 +9,11 @@ HMC_VERSION ?= 0.0.5
 TESTING_NAMESPACE ?= hmc-system
 TARGET_NAMESPACE ?= blue
 KIND_CLUSTER_NAME ?= hmc-management-local
+KIND_KUBECTL_CONTEXT = kind-$(KIND_CLUSTER_NAME)
 
 OPENSSL_DOCKER_IMAGE ?= alpine/openssl:3.3.2
 
-TEMPLATES_DIR := templates
-TEMPLATE_FOLDERS = $(patsubst $(TEMPLATES_DIR)/%,%,$(wildcard $(TEMPLATES_DIR)/*))
-CHARTS_PACKAGE_DIR ?= $(LOCALBIN)/charts
-$(CHARTS_PACKAGE_DIR): | $(LOCALBIN)
-	rm -rf $(CHARTS_PACKAGE_DIR)
-	mkdir -p $(CHARTS_PACKAGE_DIR)
-
-HELM_REGISTRY_INTERNAL_PORT ?= 5000
-HELM_REGISTRY_EXTERNAL_PORT ?= 30500
-REGISTRY_REPO ?= oci://127.0.0.1:$(HELM_REGISTRY_EXTERNAL_PORT)/helm-charts
+AWS_REGION ?= us-west-2
 
 ##@ General
 
@@ -36,7 +30,7 @@ REGISTRY_REPO ?= oci://127.0.0.1:$(HELM_REGISTRY_EXTERNAL_PORT)/helm-charts
 
 .PHONY: help
 help: ## Display this help.
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9.-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 # Checks if environment variable is set
 .check-variable-%:
@@ -112,33 +106,79 @@ $(LOCALBIN)/helm: | $(LOCALBIN)
 	curl -s --fail $(HELM_INSTALL_SCRIPT) | USE_SUDO=false HELM_INSTALL_DIR=$(LOCALBIN) DESIRED_VERSION=$(HELM_VERSION) BINARY_NAME=helm PATH="$(LOCALBIN):$(PATH)" bash
 
 
-
 ##@ General Setup
 
+# Local management cluster
 KIND_CLUSTER_CONFIG_PATH ?= $(LOCALBIN)/kind-cluster.yaml
 $(KIND_CLUSTER_CONFIG_PATH): $(LOCALBIN)
-	@cat setup/kind-cluster.yaml | envsubst > $(LOCALBIN)/kind-cluster.yaml
+	@cat setup/kind-cluster.yaml | envsubst > $(KIND_CLUSTER_CONFIG_PATH)
 
 .PHONY: bootstrap-kind-cluster
-bootstrap-kind-cluster: .check-binary-docker .check-binary-kind .check-binary-kubectl $(KIND_CLUSTER_CONFIG_PATH) ## Provision local kind cluster
+bootstrap-kind-cluster: .check-binary-docker .check-binary-kind .check-binary-kubectl
 bootstrap-kind-cluster: ## Provision local kind cluster
 	@if $(KIND) get clusters | grep -q $(KIND_CLUSTER_NAME); then\
 		echo "$(KIND_CLUSTER_NAME) kind cluster already installed";\
 	else\
+		rm -rf $(KIND_CLUSTER_CONFIG_PATH); \
+		make $(KIND_CLUSTER_CONFIG_PATH); \
 		$(KIND) create cluster --name=$(KIND_CLUSTER_NAME) --config=$(KIND_CLUSTER_CONFIG_PATH);\
 	fi
-	@$(KUBECTL) config use-context kind-$(KIND_CLUSTER_NAME)
+	@$(KUBECTL) config use-context $(KIND_KUBECTL_CONTEXT)
 
+# Deploy HMC operator
 .PHONY: deploy-2a
 deploy-2a: .check-binary-helm ## Deploy 2A to the management cluster
 	$(HELM) install hmc $(HMC_REPO) --version $(HMC_VERSION) -n $(HMC_NAMESPACE) --create-namespace
+
+# Setup Helm registry and push charts with custom Cluster and Service templates
+TEMPLATES_DIR := templates
+TEAMPLATES = $(patsubst $(TEMPLATES_DIR)/%,%,$(wildcard $(TEMPLATES_DIR)/*))
+TEMPLATE_FOLDERS = $(patsubst $(TEMPLATES_DIR)/%,%,$(wildcard $(TEMPLATES_DIR)/*))
+CHARTS_PACKAGE_DIR ?= $(LOCALBIN)/charts
+$(CHARTS_PACKAGE_DIR): | $(LOCALBIN)
+	rm -rf $(CHARTS_PACKAGE_DIR)
+	mkdir -p $(CHARTS_PACKAGE_DIR)
+
+HELM_REGISTRY_INTERNAL_PORT ?= 5000
+HELM_REGISTRY_EXTERNAL_PORT ?= 30500
+REGISTRY_REPO ?= oci://127.0.0.1:$(HELM_REGISTRY_EXTERNAL_PORT)/helm-charts
+
+.PHONY: helm-package
+helm-package: $(CHARTS_PACKAGE_DIR) .check-binary-helm
+	@make $(patsubst %,package-%-tmpl,$(TEMPLATE_FOLDERS))
+
+lint-chart-%:
+	$(HELM) dependency update $(TEMPLATES_SUBDIR)/$*
+	$(HELM) lint --strict $(TEMPLATES_SUBDIR)/$*
+
+package-%-tmpl:
+	@make TEMPLATES_SUBDIR=$(TEMPLATES_DIR)/$* $(patsubst %,package-chart-%,$(shell find $(TEMPLATES_DIR)/$* -mindepth 1 -maxdepth 1 -type d -exec basename {} \;))
+
+package-chart-%: lint-chart-%
+	$(HELM) package --destination $(CHARTS_PACKAGE_DIR) $(TEMPLATES_SUBDIR)/$*
+
+.PHONY: helm-push
+helm-push: helm-package
+	@for chart in $(CHARTS_PACKAGE_DIR)/*.tgz; do \
+		$(HELM) push "$$chart" $(REGISTRY_REPO); \
+	done
 
 .PHONY: setup-helmrepo
 setup-helmrepo: ## Deploy local helm repository and register it in 2A
 	@envsubst < setup/helmRepository.yaml | $(KUBECTL) apply -f -
 
 .PHONY: push-helm-charts
-push-helm-charts: helm-push ## Push helm charts with custom Cluster and Service templates
+push-helm-charts: ## Push helm charts with custom Cluster and Service templates
+	@while true; do\
+		if $(KUBECTL) -n $(TESTING_NAMESPACE) get deploy helm-registry; then \
+			if [[ $$($(KUBECTL) -n $(TESTING_NAMESPACE) get deploy helm-registry -o jsonpath={.status.readyReplicas}) > 0 ]]; then \
+				break; \
+			fi; \
+		fi; \
+		echo "Waiting when the helm registry be ready..."; \
+		sleep 3; \
+	done;
+	@make helm-push
 
 ##@ Infra Setup
 
@@ -164,6 +204,136 @@ setup-aws-creds: .check-variable-aws-access-key .check-variable-aws-secret-acces
 setup-azure-creds: .check-variable-azure-sp-password .check-variable-azure-sp-app-id .check-variable-azure-sp-tenant-id ## Setup Azure credentials
 	envsubst < setup/azure-credentials.yaml | kubectl apply -f -
 
+## Common targets and functions
+apply-%: NAMESPACE = $(TESTING_NAMESPACE)
+apply-%: SHOW_DIFF = true
+apply-%:
+	@if [[ "$$SHOW_DIFF" == "true" ]]; then \
+		echo "Applying changes: "; \
+		envsubst < $(template_path) | KUBECTL_EXTERNAL_DIFF="diff --color -N -u" $(KUBECTL) diff  -f - || true; \
+	fi
+	@envsubst < $(template_path) | $(KUBECTL) apply -f -
+
+watch-%: namespace = $(TESTING_NAMESPACE)
+watch-%:
+	@$(KUBECTL) get -n $(NAMESPACE) managedcluster.hmc.mirantis.com $(full_cluster_name) --watch
+
+KUBECONFIGS_DIR = $(shell pwd)/kubeconfigs
+$(KUBECONFIGS_DIR):
+	@mkdir -p $(KUBECONFIGS_DIR)
+
+get-kubeconfig-%: NAMESPACE = $(TESTING_NAMESPACE)
+get-kubeconfig-%:
+	@$(KUBECTL) -n $(NAMESPACE) get secret $(full_cluster_name)-kubeconfig -o jsonpath='{.data.value}' | base64 -d > $(KUBECONFIGS_DIR)/$(full_cluster_name).kubeconfig
+
+# TODO: 
+# It replaces the rule in .spec.accessRules with removing all previous data. 
+# Previously provisioned objects are not deleted from the target namespace though - maybe a bug?
+approve-%:
+	@kubectl -n $(HMC_NAMESPACE) patch AccessManagement hmc --type='json' -p='[ { "op": "add", "path": "/spec/accessRules", "value": [] }, { "op": "add", "path": "/spec/accessRules/-", "value": { $(patsubst %,"credentials": ["%"]$(shell echo ,),$(credential_name)) $(patsubst %,"clusterTemplateChains": ["%"]$(shell echo ,),$(cluster_template_name)) "targetNamespaces": { "list": ["$(TARGET_NAMESPACE)"] } }}]'
+
+##@ Demo 1
+
+apply-clustertemplate-demo-aws-standalone-cp-0.0.1: SHOW_DIFF = false
+apply-clustertemplate-demo-aws-standalone-cp-0.0.1: template_path = templates/cluster/demo-aws-standalone-cp-0.0.1.yaml
+apply-clustertemplate-demo-aws-standalone-cp-0.0.1: ## Deploy custom demo-aws-standalone-cp-0.0.1 ClusterTemplate
+
+apply-managed-cluster-aws-test1-0.0.1: CLUSTERNAME = test1
+apply-managed-cluster-aws-test1-0.0.1: template_path = managedClusters/aws/0.0.1.yaml
+apply-managed-cluster-aws-test1-0.0.1: ## Deploy managed cluster test1 version 0.0.1 to AWS
+
+watch-aws-test1: full_cluster_name = hmc-system-aws-test1
+watch-aws-test1: ## Monitor the provisioning process of the managed cluster test1 in AWS
+
+get-kubeconfig-aws-test1: full_cluster_name = hmc-system-aws-test1
+get-kubeconfig-aws-test1: ## Get kubeconfig for the cluster test1
+
+apply-managed-cluster-aws-test2-0.0.1: CLUSTERNAME = test2
+apply-managed-cluster-aws-test2-0.0.1: template_path = managedClusters/aws/0.0.1.yaml
+apply-managed-cluster-aws-test2-0.0.1: ## Deploy managed cluster test2 version 0.0.1 to AWS
+
+watch-aws-test2: full_cluster_name = hmc-system-aws-test2
+watch-aws-test2: ## Monitor the provisioning process of the managed cluster test2 in AWS
+
+get-kubeconfig-aws-test2: full_cluster_name = hmc-system-aws-test2
+get-kubeconfig-aws-test2: ## Get kubeconfig for the cluster test2
+
+##@ Demo 2
+
+apply-clustertemplate-demo-aws-standalone-cp-0.0.2: SHOW_DIFF = false
+apply-clustertemplate-demo-aws-standalone-cp-0.0.2: template_path = templates/cluster/demo-aws-standalone-cp-0.0.2.yaml
+apply-clustertemplate-demo-aws-standalone-cp-0.0.2: ## Deploy custom demo-aws-standalone-cp-0.0.2 ClusterTemplate
+
+get-avaliable-upgrades: ## Get available upgrades for all managed clusters
+	@$(KUBECTL) -n $(TESTING_NAMESPACE) get managedcluster.hmc.mirantis.com -o go-template='{{ range $$_,$$cluster := .items }}Cluster {{ $$cluster.metadata.name}} available upgrades: {{"\n"}}{{ range $$_,$$upgrade := $$cluster.status.availableUpgrades}}{{"\t- "}}{{ $$upgrade }}{{"\n"}}{{ end }}{{"\n"}}{{ end }}'
+
+apply-managed-cluster-aws-test1-0.0.2: CLUSTERNAME = test1
+apply-managed-cluster-aws-test1-0.0.2: template_path = managedClusters/aws/0.0.2.yaml
+apply-managed-cluster-aws-test1-0.0.2: ## Upgrade managed cluster test2 to version 0.0.2
+
+##@ Demo 3
+
+apply-servicetemplate-demo-ingress-nginx-4.11.0: SHOW_DIFF = false
+apply-servicetemplate-demo-ingress-nginx-4.11.0: template_path = templates/service/demo-ingress-nginx-4.11.0.yaml
+apply-servicetemplate-demo-ingress-nginx-4.11.0: ## Deploy custom demo-ingress-nginx-4.11.0 ServiceTemplate
+
+apply-managed-cluster-aws-test2-0.0.1-ingress: CLUSTERNAME = test2
+apply-managed-cluster-aws-test2-0.0.1-ingress: template_path = managedClusters/aws/0.0.1-ingress.yaml
+apply-managed-cluster-aws-test2-0.0.1-ingress: ## Deploy ingress service to the managed cluster test2 in AWS
+
+##@ Demo 4
+
+apply-servicetemplate-demo-kyverno-3.2.6: SHOW_DIFF = false
+apply-servicetemplate-demo-kyverno-3.2.6: template_path = templates/service/demo-kyverno-3.2.6.yaml
+apply-servicetemplate-demo-kyverno-3.2.6: ## Deploy custom demo-kyverno-3.2.6
+
+apply-multiclusterservice-global-kyverno: template_path = MultiClusterServices/1-global-kyverno.yaml
+apply-multiclusterservice-global-kyverno: ## Deploy MultiClusterService global-kyverno that installs kyverno service to all managed clusters
+
+##@ Demo 5
+
+.PHONY: create-target-namespace-rolebindings
+create-target-namespace-rolebindings:
+	@kubectl get namespace $(TARGET_NAMESPACE) > /dev/null 2>&1 || kubectl create namespace $(TARGET_NAMESPACE)
+	@envsubst < rolebindings.yaml | kubectl apply -f -
+
+.PHONY: generate-platform-engineer1-kubeconfig
+generate-platform-engineer1-kubeconfig: USER_NAME = platform-engineer1
+generate-platform-engineer1-kubeconfig:
+	@make certs/$(USER_NAME)/$(USER_NAME).crt
+	@USER_CRT=$$(cat certs/$(USER_NAME)/$(USER_NAME).crt | base64 | tr -d '\n\r') \
+		USER_KEY=$$(cat certs/$(USER_NAME)/$(USER_NAME).key | base64 | tr -d '\n\r')  \
+		CA_CRT=$$(cat certs/ca/ca.crt | base64 | tr -d '\n\r') \
+		CLUSTER_HOST_PORT=$$(docker port $(KIND_CLUSTER_NAME)-control-plane 6443) \
+		envsubst < certs/kubeconfig-template.yaml > certs/$(USER_NAME)/kubeconfig.yaml
+	@echo "Config exported to certs/$(USER_NAME)/kubeconfig.yaml"
+
+approve-clustertemplatechain-aws-standalone-cp-0.0.1: cluster_template_name = demo-aws-standalone-cp-0.0.1
+approve-clustertemplatechain-aws-standalone-cp-0.0.1: ## Approve ClusterTemplate into the target namespace
+
+approve-credential-aws: credential_name = aws-cluster-identity-cred
+approve-credential-aws: ## Approve AWS Credentials into the target namespace
+
+##@ Demo 6
+
+apply-managed-cluster-aws-dev1-0.0.1: CLUSTERNAME = dev1
+apply-managed-cluster-aws-dev1-0.0.1: template_path = managedClusters/aws/0.0.1.yaml
+apply-managed-cluster-aws-dev1-0.0.1: NAMESPACE = $(TARGET_NAMESPACE)
+apply-managed-cluster-aws-dev1-0.0.1: KUBECONFIG="certs/platform-engineer1/kubeconfig.yaml"
+apply-managed-cluster-aws-dev1-0.0.1: ## Deploy managed cluster AWS dev1 version 0.0.1 to the blue namespace as Platform Engineer
+
+watch-aws-dev1: full_cluster_name = blue-aws-dev1
+watch-aws-dev1: namespace = $(TARGET_NAMESPACE)
+watch-aws-dev1: KUBECONFIG="certs/platform-engineer1/kubeconfig.yaml"
+watch-aws-dev1: ## Monitor the provisioning process of the managed AWS cluster dev1 in blue namespace
+
+get-kubeconfig-aws-dev1: full_cluster_name = blue-aws-dev1
+get-kubeconfig-aws-dev1: KUBECONFIG="certs/platform-engineer1/kubeconfig.yaml"
+get-kubeconfig-aws-dev1: NAMESPACE = $(TARGET_NAMESPACE)
+get-kubeconfig-aws-dev1: ## Get kubeconfig for the cluster dev1 in the blue namespace
+
+
+
 ##@ TBD
 
 # install-template will install a given template
@@ -172,25 +342,9 @@ define install-template
 	kubectl apply -f $(1)
 endef
 
-.PHONY: install-clustertemplate-demo-aws-standalone-cp-0.0.1
-install-clustertemplate-demo-aws-standalone-cp-0.0.1:
-	$(call install-template,templates/cluster/demo-aws-standalone-cp-0.0.1.yaml)
-
-.PHONY: install-clustertemplate-demo-aws-standalone-cp-0.0.2
-install-clustertemplate-demo-aws-standalone-cp-0.0.2:
-	$(call install-template,templates/cluster/demo-aws-standalone-cp-0.0.2.yaml)
-
-.PHONY: install-servicetemplate-demo-ingress-nginx-4.11.0
-install-servicetemplate-demo-ingress-nginx-4.11.0:
-	$(call install-template,templates/service/demo-ingress-nginx-4.11.0.yaml)
-
 .PHONY: install-servicetemplate-demo-ingress-nginx-4.11.3
 install-servicetemplate-demo-ingress-nginx-4.11.3:
 	$(call install-template,templates/service/demo-ingress-nginx-4.11.3.yaml)
-
-.PHONY: install-servicetemplate-demo-kyverno-3.2.6
-install-servicetemplate-demo-kyverno-3.2.6:
-	$(call install-template,templates/service/demo-kyverno-3.2.6.yaml)
 
 # apply-managed-cluster-yaml will apply a given cluster yaml
 # $1 - target namespace
@@ -214,46 +368,16 @@ define apply-managed-cluster-yaml-platform-engineer1
 	NAMESPACE=$(1) CLUSTERNAME=$(2) envsubst < $(3) | KUBECONFIG="certs/platform-engineer1/kubeconfig.yaml" kubectl apply -f -
 endef
 
-.PHONY: apply-aws-test1-0.0.1
-apply-aws-test1-0.0.1:
-	$(call apply-managed-cluster-yaml,$(TESTING_NAMESPACE),test1,managedClusters/aws/0.0.1.yaml)
-
-.PHONY: watch-aws-test1
-watch-aws-test1:
-	kubectl get -n $(TESTING_NAMESPACE) ManagedCluster.hmc.mirantis.com hmc-system-aws-test1 --watch
 
 .PHONY: apply-aws-test1-0.0.1-ingress
 apply-aws-test1-0.0.1-ingress:
 	$(call apply-managed-cluster-yaml,$(TESTING_NAMESPACE),test1,managedClusters/aws/0.0.1-ingress.yaml)
 
-.PHONY: get-kubeconfig-aws-test1
-get-kubeconfig-aws-test1:
-	kubectl -n $(TESTING_NAMESPACE) get secret hmc-system-aws-test1-kubeconfig -o jsonpath='{.data.value}' | base64 -d > kubeconfigs/hmc-system-aws-test1.kubeconfig
 
-.PHONY: apply-aws-test1-0.0.2
-apply-aws-test1-0.0.2:
-	$(call apply-managed-cluster-yaml,$(TESTING_NAMESPACE),test1,managedClusters/aws/0.0.2.yaml)
 
 .PHONY: apply-aws-test1-0.0.2-ingress
 apply-aws-test1-0.0.2-ingress:
 	$(call apply-managed-cluster-yaml,$(TESTING_NAMESPACE),test1,managedClusters/aws/0.0.2-ingress.yaml)
-
-
-.PHONY: apply-aws-test2-0.0.1
-apply-aws-test2-0.0.1:
-	$(call apply-managed-cluster-yaml,$(TESTING_NAMESPACE),test2,managedClusters/aws/0.0.1.yaml)
-
-.PHONY: watch-aws-test2
-watch-aws-test2:
-	kubectl get -n $(TESTING_NAMESPACE) ManagedCluster.hmc.mirantis.com hmc-system-aws-test2 --watch
-
-.PHONY: apply-aws-test2-0.0.1-ingress
-apply-aws-test2-0.0.1-ingress:
-	$(call apply-managed-cluster-yaml,$(TESTING_NAMESPACE),test2,managedClusters/aws/0.0.1-ingress.yaml)
-
-.PHONY: get-kubeconfig-aws-test2
-get-kubeconfig-aws-test2:
-	kubectl -n $(TESTING_NAMESPACE) get secret hmc-system-aws-test2-kubeconfig -o jsonpath='{.data.value}' | base64 -d > kubeconfigs/hmc-system-aws-test2.kubeconfig
 
 .PHONY: apply-aws-test2-0.0.2
 apply-aws-test2-0.0.2:
@@ -280,13 +404,9 @@ apply-aws-prod1-ingress-0.0.2:
 	$(call apply-managed-cluster-yaml-platform-engineer1,$(TARGET_NAMESPACE),prod1,managedClusters/aws/0.0.2-ingress.yaml)
 
 
-.PHONY: apply-aws-dev1-0.0.1
-apply-aws-dev1-0.0.1:
-	$(call apply-managed-cluster-yaml-platform-engineer1,$(TARGET_NAMESPACE),dev1,managedClusters/aws/0.0.1.yaml)
 
-.PHONY: get-kubeconfig-aws-dev1
-get-kubeconfig-aws-dev1:
-	KUBECONFIG="certs/platform-engineer1/kubeconfig.yaml" kubectl -n $(TARGET_NAMESPACE) get secret blue-aws-test1-kubeconfig -o jsonpath='{.data.value}' | base64 -d > kubeconfigs/$(TARGET_NAMESPACE)-aws-dev1.kubeconfig
+
+
 
 .PHONY: apply-aws-dev1-ingress-0.0.1
 apply-aws-dev1-ingress-0.0.1:
@@ -340,14 +460,6 @@ apply-azure-dev1-0.0.2:
 apply-azure-dev1-ingress-0.0.2:
 	$(call apply-managed-cluster-yaml,$(TARGET_NAMESPACE),dev1,azure/3-ingress-0.0.2.yaml)
 
-
-apply-multiclusterservice-global-kyverno:
-	KUBECTL_EXTERNAL_DIFF="diff --color -N -u" kubectl -n $(TESTING_NAMESPACE) diff -f MultiClusterServices/1-global-kyverno.yaml || true
-	kubectl -n $(TESTING_NAMESPACE) apply -f MultiClusterServices/1-global-kyverno.yaml
-
-.PHONY: approve-clustertemplatechain-aws-standalone-cp-0.0.1
-approve-clustertemplatechain-aws-standalone-cp-0.0.1:
-	$(call approve-clustertemplatechain,$(TARGET_NAMESPACE),demo-aws-standalone-cp-0.0.1)
 
 .PHONY: approve-clustertemplatechain-aws-standalone-cp-0.0.2
 approve-clustertemplatechain-aws-standalone-cp-0.0.2:
@@ -423,14 +535,7 @@ endef
 approve-credential-azure:
 	$(call approve-credential,$(TARGET_NAMESPACE),azure-cluster-identity-cred)
 
-.PHONY: approve-credential-aws
-approve-credential-aws:
-	$(call approve-credential,$(TARGET_NAMESPACE),aws-cluster-identity-cred)
 
-.PHONY: create-target-namespace-rolebindings
-create-target-namespace-rolebindings:
-	kubectl get namespace $(TARGET_NAMESPACE) > /dev/null 2>&1 || kubectl create namespace $(TARGET_NAMESPACE)
-	TARGET_NAMESPACE=$(TARGET_NAMESPACE) envsubst < rolebindings.yaml | kubectl apply -f -
 
 certs/ca/ca.crt:
 	mkdir -p certs/ca
@@ -454,56 +559,29 @@ certs/platform-engineer1/platform-engineer1.crt: certs/platform-engineer1/platfo
 
 .PHONY: cleanup-clusters
 cleanup-clusters: clean-certs ## Tear down managed cluster
-	# use the explicit --context option to be specific about which cluster should be used to prevent disaster
-	kubectl --context=kind-$(KIND_CLUSTER_NAME) delete managedclusters.hmc.mirantis.com -n $(HMC_NAMESPACE) --all
+	@if $(KIND) get clusters | grep -q $(KIND_CLUSTER_NAME); then \
+		$(KUBECTL) --context=$(KIND_KUBECTL_CONTEXT) delete managedcluster.hmc.mirantis.com -n $(TESTING_NAMESPACE) --all --wait=false 2>/dev/null || true; \
+		while [[ $$($(KUBECTL) -n $(TESTING_NAMESPACE) get managedcluster.hmc.mirantis.com -o go-template='{{ len .items }}' 2>/dev/null || echo 0) > 0 ]]; do \
+			echo "Waiting untill all managed clusters are deleted..."; \
+			sleep 3; \
+		done; \
+	fi
 
 .PHONY: cleanup
-cleanup: cleanup-clusters clean-certs ## Tear down management cluster
+cleanup: cleanup-clusters clean-certs clean-configs
+cleanup: ## Tear down management cluster
 	@if $(KIND) get clusters | grep -q $(KIND_CLUSTER_NAME); then\
-		$(KIND) kind delete cluster --name=$(KIND_CLUSTER_NAME);\
+		$(KIND) delete cluster --name=$(KIND_CLUSTER_NAME);\
 	else\
 		echo "Can't find kind cluster with the name $(KIND_CLUSTER_NAME)";\
 	fi
 
+.PHONY: clean-configs
+clean-configs:
+	@rm -rf $(KIND_CLUSTER_CONFIG_PATH)
+	@rm -rf $(LOCALBIN)/charts
+
 .PHONY: clean-certs
 clean-certs:
-	rm -rf certs/ca
-	rm -rf certs/platform-engineer
-
-.PHONY: generate-platform-engineer1-kubeconfig
-generate-platform-engineer1-kubeconfig: certs/platform-engineer1/platform-engineer1.crt
-	KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) USER_NAME=platform-engineer1 USER_CRT=$$(cat certs/platform-engineer1/platform-engineer1.crt | base64) USER_KEY=$$(cat certs/platform-engineer1/platform-engineer1.key | base64)  CA_CRT=$$(cat certs/ca/ca.crt | base64) CLUSTER_HOST_PORT=$$(docker port $(KIND_CLUSTER_NAME)-control-plane 6443) envsubst < certs/kubeconfig-template.yaml > certs/platform-engineer1/kubeconfig.yaml
-	@echo "Config exported to certs/platform-engineer1/kubeconfig.yaml"
-
-.PHONY: helm-package
-helm-package: $(CHARTS_PACKAGE_DIR) .check-binary-helm
-	@make $(patsubst %,package-%-tmpl,$(TEMPLATE_FOLDERS))
-
-TEAMPLATES = $(patsubst $(TEMPLATES_DIR)/%,%,$(wildcard $(TEMPLATES_DIR)/*))
-
-lint-chart-%:
-	$(HELM) dependency update $(TEMPLATES_SUBDIR)/$*
-	$(HELM) lint --strict $(TEMPLATES_SUBDIR)/$*
-
-package-%-tmpl:
-	@make TEMPLATES_SUBDIR=$(TEMPLATES_DIR)/$* $(patsubst %,package-chart-%,$(shell find $(TEMPLATES_DIR)/$* -mindepth 1 -maxdepth 1 -type d -exec basename {} \;))
-
-
-package-chart-%: lint-chart-%
-	$(HELM) package --destination $(CHARTS_PACKAGE_DIR) $(TEMPLATES_SUBDIR)/$*
-
-.PHONY: helm-push
-helm-push: helm-package
-	@for chart in $(CHARTS_PACKAGE_DIR)/*.tgz; do \
-		base=$$(basename $$chart .tgz); \
-		chart_version=$$(echo $$base | grep -o "v\{0,1\}[0-9]\+\.[0-9]\+\.[0-9].*"); \
-		chart_name="$${base%-"$$chart_version"}"; \
-		echo "Verifying if chart $$chart_name, version $$chart_version already exists in $(REGISTRY_REPO)"; \
-		chart_exists=$$($(HELM) show chart $(REGISTRY_REPO)/$$chart_name --version $$chart_version 2>&1 | grep "failed to download" || true); \
-		if [ -z "$$chart_exists" ]; then \
-			echo "Chart $$chart_name version $$chart_version already exists in the repository."; \
-		else \
-			echo "Pushing $$chart to $(REGISTRY_REPO)"; \
-			$(HELM) push "$$chart" $(REGISTRY_REPO); \
-		fi; \
-	done
+	@rm -rf certs/ca
+	@rm -rf certs/platform-engineer*

--- a/MultiClusterServices/1-global-kyverno.yaml
+++ b/MultiClusterServices/1-global-kyverno.yaml
@@ -8,6 +8,6 @@ spec:
     matchLabels:
       app.kubernetes.io/managed-by: Helm
   services:
-    - template: kyverno-3-2-6
+    - template: demo-kyverno-3.2.6
       name: kyverno
       namespace: kyverno

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ To get the full list of commands run `make help`.
 
 ### General Setup
 
+> Expected completion time ~10 min
+
 1. Create a 2A Management cluster with kind:
     ```shell
     make bootstrap-kind-cluster
@@ -28,12 +30,13 @@ To get the full list of commands run `make help`.
     ```shell
     make deploy-2a
     ```
-    The Demos in this repo require at least 2A v0.0.5 or newer. You can change the version of 2A by specifying the `HMC_VERSION` environment variable.
+    The Demos in this repo require at least 2A v0.0.5 or newer. You can change the version of 2A by specifying the `HMC_VERSION` environment variable. List of releases can be found [here](https://github.com/Mirantis/hmc/releases).
 
 3. Monitor the installation of 2A:
     ```shell
     PATH=$PATH:./bin kubectl get management hmc -o go-template='{{range $key, $value := .status.components}}{{$key}}: {{if $value.success}}{{$value.success}}{{else}}{{$value.error}}{{end}}{{"\n"}}{{end}}'
     ```
+    In this command we track the `Management` object that is created by the operator. Don't worry if you get error that the object is not found, it can take some time.
     If the installation of 2a succeeded, the output should look as follows
     ```
     capi: true
@@ -62,6 +65,8 @@ To get the full list of commands run `make help`.
 
 ### Infra Setup
 
+> Expected completion time ~2 min
+
 As next you need to decide into which infrastructure you would like to install the Demo clusters. This Demo Repo has support for the following Infra Providers (more to follow in the future):
 
 - AWS
@@ -72,17 +77,33 @@ As next you need to decide into which infrastructure you would like to install t
 This assumes that you already have configured the required [AWS IAM Roles](https://mirantis.github.io/project-2a-docs/quick-start/aws/#configure-aws-iam) and have an [AWS account with the required permissions](https://mirantis.github.io/project-2a-docs/quick-start/aws/#step-1-create-aws-iam-user). If not follow the 2A documentation steps for them.
 
 1. Export AWS Keys as environment variables:
-    ```
+    ```shell
     export AWS_ACCESS_KEY_ID="AKIAQIUDYGHDSJ3RZJC"
     export AWS_SECRET_ACCESS_KEY="hk8RAdjyfsiuhs7sG/kxLS+XS2xUHDUhfiuydZ4nSW"
     ````
+2. By default, it will provision all resources in the `us-west-2` AWS region. If you want to change this, export `AWS_REGION` environment variable:
+    ```shell
+    export AWS_REGION="us-east-1"
+    ```
 
-2. Install Credentials into 2A:
+3. Install Credentials into 2A:
     ```shell
     make setup-aws-creds
     ```
 
+4. Check that credentials are ready to use
+    ```shell
+    PATH=$PATH:./bin kubectl -n hmc-system get credentials aws-cluster-identity-cred
+    ```
+    The output should be similar to:
+    ```
+    NAME                        READY   DESCRIPTION
+    aws-cluster-identity-cred   true    Basic AWS credentials
+    ```
+
 #### Azure Setup
+
+**Currently demos don't have Azure cluster deployments, so you can skip this section**
 
 This assumes that you already have configured the required [Azure providers](https://mirantis.github.io/project-2a-docs/quick-start/azure/#register-resource-providers) and created a [Azure Service Principal](https://mirantis.github.io/project-2a-docs/quick-start/azure/#step-2-create-a-service-principal-sp).
 
@@ -98,21 +119,38 @@ This assumes that you already have configured the required [Azure providers](htt
     make setup-azure-creds
     ```
 
+3. Check that credentials are ready to use
+    ```shell
+    PATH=$PATH:./bin kubectl -n hmc-system get credentials azure-credential
+    ```
+    The output should be similar to:
+    ```
+    NAME               READY   DESCRIPTION
+    azure-credential   true    Basic Azure credentials
+    ```
+
 ### Demo Cluster Setup
+
+**Skip this step if you just want to run demos for your own**
 
 If your plan is to demo an upgrade (Demo 2) or anything related to ServiceTemplates (Demo 3 & 4) right after Demo 1, it is recommended to create a test cluster before the actual demo starts. The reason for this is that creation of a cluster takes around 10-15 mins and could cause a long waiting time during the demo. If you already have a second cluster you can show the creation of a cluster (Demo 1) and then use the existing cluster to show the other demos.
 
 
 1. Install templates and create aws-test1 cluster
     ```shell
-    make install-clustertemplate-demo-aws-standalone-cp-0.0.1
-    make apply-aws-test1-0.0.1
+    make apply-clustertemplate-demo-aws-standalone-cp-0.0.1
+    make apply-managed-cluster-aws-test1-0.0.1
     make watch-aws-test1
+    ```
+2. Wait when the managed cluster be in Ready state:
+    ```
+    NAME                   READY   STATUS
+    hmc-system-aws-test1   True    ManagedCluster is ready
     ```
 
 ### Blue Namespace & Platform Engineer Credentials
 
-If you plan to demo Demo 5 or above we need a secondary namespace (we call it blue in this demo) and credentials for a Platform Engineer that does only have access to the blue namespace and not cluster admin.
+If you plan to run the [`Demo 5`](#demo-5-approve-clustertemplate--infracredentials-for-separate-namespace) or above we need a secondary namespace (we call it `blue` in this demo) and credentials for a Platform Engineer that does only have access to the blue namespace and not cluster admin.
 
 1. Create target namespace blue and required rolebindings
     ```shell
@@ -127,10 +165,12 @@ If you plan to demo Demo 5 or above we need a secondary namespace (we call it bl
 
 3. Test Kubeconfig
     ```shell
-    KUBECONFIG="certs/platform-engineer1/kubeconfig.yaml" kubectl get ns blue
+    KUBECONFIG="certs/platform-engineer1/kubeconfig.yaml" PATH=$PATH:./bin kubectl get ns blue
     ```
 
 ## Demo 1: Standalone Cluster Deployment
+
+> Expected completion time ~10-15 min
 
 This demo shows how a simple standalone cluster from a custom ClusterTemplate can be created in the `hmc-system` namespace. It does not require any additional users in k8s or namespaces to be installed.
 
@@ -139,109 +179,226 @@ In the real world this would most probably be done by a Platform Team Lead that 
 
 1. Install ClusterTemplate in 2A
     ```shell
-    make install-clustertemplate-demo-aws-standalone-cp-0.0.1
+    make apply-clustertemplate-demo-aws-standalone-cp-0.0.1
     ```
-    This will install the custom ClusterTmplate and ClusterTemplateChain `demo-aws-standalone-cp-0.0.1` which exists in this Git Repo under `templates/cluster/demo-aws-standalone-cp-0.0.1` is hosted on the Github OCI registry at https://github.com/Mirantis/2a-demos.
+    This will install the custom [ClusterTemplate and ClusterTemplateChain](./templates/cluster/demo-aws-standalone-cp-0.0.1.yaml) `demo-aws-standalone-cp-0.0.1`. ClusterTemplate refers to the [Helm chart](./templates/cluster/demo-aws-standalone-cp-0.0.1/) `demo-aws-standalone-cp` of version `0.0.1` which was published to the local Helm repository on the Infra Setup steps.
 
-    @TODO: add `kubectl -n hmc-system get clustertemplate`
+    You can find this new ClusterTemplate in the list of template with the command:
+    ```shell
+    PATH=$PATH:./bin kubectl -n hmc-system get clustertemplates
+    ```
 
-    To make an even simpler Demo, this step could be done before the actual demo starts.
+    Example of the output:
+    ```
+    NAME                           VALID
+    aws-eks-0-0-2                  true
+    aws-hosted-cp-0-0-3            true
+    aws-standalone-cp-0-0-4        true
+    azure-hosted-cp-0-0-3          true
+    azure-standalone-cp-0-0-4      true
+    demo-aws-standalone-cp-0.0.1   true <-- this is the installed template
+    vsphere-hosted-cp-0-0-3        true
+    vsphere-standalone-cp-0-0-3    true
+    ```
 
-    As assumed by 2A all ClusterTemplates will be installed first into the `hmc-system` Namespace and can there be used directly to create a Cluster:
+    > Hint: To make an even simpler Demo, this step could be done before the actual demo starts.
+
+    As assumed by 2A all ClusterTemplates will be installed first into the `hmc-system` Namespace and can there be used directly to create a new managed cluster.
 
 2. Install Test Clusters:
     ```shell
-    make apply-aws-test1-0.0.1
-    make apply-aws-test2-0.0.1
+    make apply-managed-cluster-aws-test1-0.0.1
+    make apply-managed-cluster-aws-test2-0.0.1
     ```
-    This will create `ManagedCluster` with very simple defaults from the ClusterTemplate `demo-aws-standalone-cp-0.0.1`.
-    The yaml for this can be found under `managedClusters/aws/1-0.0.1.yaml` and could be modified if needed.
+    This will create 2 objects of type `ManagedCluster` with very simple defaults from the ClusterTemplate `demo-aws-standalone-cp-0.0.1`.
+    The yaml for this can be found under [`managedClusters/aws/0.0.1.yaml`](./managedClusters/aws/0.0.1.yaml) and could be modified if needed.
     The Make command also shows the actual yaml that is created for an easier demo experience.
 
+3. Monitor the deployment of each cluster and wait when both be in Ready state:
+    For the first cluster:
+    ```shell
+    make watch-aws-test1
+    ```
 
-3. Monitor the deployment of the Cluster:
+    Example of the output of fully deployed first cluster:
+    ```
+    NAME                   READY   STATUS
+    hmc-system-aws-test1   True    ManagedCluster is ready
+    ```
+
+    For the seocnd cluster:
     ```shell
     make watch-aws-test2
     ```
-    This will show the status and rollout of the cluster as seen by 2A.
-
+    
+    Example of the output of fully deployed second cluster:
+    ```
+    NAME                   READY   STATUS
+    hmc-system-aws-test2   True    ManagedCluster is ready
+    ```
 
 4. Create Kubeconfig for Clusters:
     ```shell
     make get-kubeconfig-aws-test1
     make get-kubeconfig-aws-test2
-    ````
-    This will put a kubeconfig for a cluster admin under the folder `kubeconfigs`
+    ```
+    This will put kubeconfigs for a cluster admin under the folder `kubeconfigs` for both created clusters
 
 
 5. Access Clusters through kubectl
     ```shell
-    KUBECONFIG="kubeconfigs/hmc-system-aws-test1.kubeconfig" kubectl get pods -A
+    KUBECONFIG="kubeconfigs/hmc-system-aws-test1.kubeconfig" PATH=$PATH:./bin kubectl get node
+    ```
+
+    Example output:
+    ```
+    NAME                                  STATUS   ROLES           AGE   VERSION
+    hmc-system-aws-test1-cp-0             Ready    control-plane   58m   v1.31.2+k0s
+    hmc-system-aws-test1-md-xh4b5-h7qr5   Ready    <none>          49m   v1.31.2+k0s
+    hmc-system-aws-test1-md-xh4b5-hpmvk   Ready    <none>          49m   v1.31.2+k0s
     ```
 
     ```shell
-    KUBECONFIG="kubeconfigs/hmc-system-aws-test2.kubeconfig" kubectl get pods -A
+    KUBECONFIG="kubeconfigs/hmc-system-aws-test2.kubeconfig" PATH=$PATH:./bin kubectl get node
+    ```
+
+    Example output:
+    ```
+    NAME                                  STATUS   ROLES           AGE   VERSION
+    hmc-system-aws-test2-cp-0             Ready    control-plane   58m   v1.31.2+k0s
+    hmc-system-aws-test2-md-xh4b5-h7qr5   Ready    <none>          49m   v1.31.2+k0s
+    hmc-system-aws-test2-md-xh4b5-hpmvk   Ready    <none>          49m   v1.31.2+k0s
     ```
 
 ## Demo 2: Single Standalone Cluster Upgrade
 
-This demo shows how to upgrade an existing cluster through the cluster template system. This expects `Demo 1` to be completed or the `aws-test1` cluster already created during the Demo Setup.
+> Expected completion time ~10 min
+
+This demo shows how to upgrade an existing cluster through the cluster template system. This expects [Demo 1](#demo-1-standalone-cluster-deployment) to be completed or the `aws-test1` cluster already created during the [Demo Setup](#demo-cluster-setup).
 
 This demo will upgrade the k8s cluster from `v1.31.1+k0s.1` (which is part of the `demo-aws-standalone-cp-0.0.1` template) to `v1.31.2+k0s.0` (which is part of `demo-aws-standalone-cp-0.0.2`)
 
 1. Install ClusterTemplate Upgrade
     ```shell
-    make install-clustertemplate-demo-aws-standalone-cp-0.0.2
+    make apply-clustertemplate-demo-aws-standalone-cp-0.0.2
     ```
-    This will actually not only install a ClusterTemplate but also a ClusterTemplateChain. This ClusterTemplateChain will tell 2A that the `demo-aws-standalone-cp-0.0.2` is an upgrade from `demo-aws-standalone-cp-0.0.1`. You can see the source for it [here](templates/cluster/demo-aws-standalone-cp-0.0.2.yaml).
+    This will actually not only install a [ClusterTemplate but also a ClusterTemplateChain](./templates/cluster/demo-aws-standalone-cp-0.0.2.yaml). This ClusterTemplateChain will tell 2A that the `demo-aws-standalone-cp-0.0.2` is an upgrade from `demo-aws-standalone-cp-0.0.1`.
 
+    You can find this new ClusterTemplate in the list of template with the command:
+    ```shell
+    PATH=$PATH:./bin kubectl -n hmc-system get clustertemplates
+    ```
 
-2. The fact that we have an upgrade available will be reported by 2A, and can be checked with:
+    Example of the output:
+    ```
+    NAME                           VALID
+    ...
+    demo-aws-standalone-cp-0.0.1   true
+    demo-aws-standalone-cp-0.0.2   true <-- this is the new template
+    ...
+    ```
+
+2. The fact that we have an upgrade available will be reported by 2A. You can find all available upgrades for all managed clusters by running this command:
 
     ```shell
-    kubectl -n hmc-system get managedcluster.hmc.mirantis.com hmc-system-aws-test1 -o jsonpath='{.status.availableUpgrades}'
+    make get-avaliable-upgrades
     ```
 
-    @TODO: change command to load all clusters
-    example output:
+    Example output:
     ```
-    [
-      "demo-aws-standalone-cp-0.0.2"
-    ]
+    Cluster hmc-system-aws-test1 available upgrades: 
+      - demo-aws-standalone-cp-0.0.2
+    Cluster hmc-system-aws-test2 available upgrades: 
+      - demo-aws-standalone-cp-0.0.2
     ```
 
 3. Apply Upgrade of the cluster:
     ```shell
-    make apply-aws-test1-0.0.2
+    make apply-managed-cluster-aws-test1-0.0.2
     ```
 
-
 4. Monitor the rollout of the upgrade
-   ```shell
-   KUBECONFIG="kubeconfigs/hmc-system-aws-test1.kubeconfig" kubectl get nodes --all-namespaces --watch
-   ```
+
+    You can watch how new machines are created and old machines are deleted:
+    ```shell
+    PATH=$PATH:./bin kubectl -n hmc-system get machines -w
+    ```
+
+    > Hint: control plane nodes for k0s clusters are being upgraded in place (check the version field) without provisioning new machines.
+
+    And how in the managed cluster old nodes are drained and new nodes are attached:
+    ```shell
+    KUBECONFIG="kubeconfigs/hmc-system-aws-test1.kubeconfig" PATH=$PATH:./bin kubectl get node -w
+    ```
 
 ## Demo 3: Install ServiceTemplate into single Cluster
 
+> Expected completion time ~5 min
+
 This demo shows how a ServiceTemplate can be installed in a Cluster.
 
-In order to run this demo you need `Demo 1` completed, which created the `aws-test2` cluster.
+In order to run this demo you need [`Demo 1`](#demo-1-standalone-cluster-deployment) completed, which created the `test2` cluster.
 
 1. Install ServiceTemplate in 2A:
     ```shell
-    make install-servicetemplate-demo-ingress-nginx-4.11.0
+    make apply-servicetemplate-demo-ingress-nginx-4.11.0
+    ```
+
+    This installs the custom [ServiceTemplate and ServiceTemplateChain](./templates/service/demo-ingress-nginx-4.11.0.yaml) `demo-ingress-nginx-4.11.0`. ServiceTemplate refers to the [Helm chart](./templates/service/demo-ingress-nginx-4.11.0/) `demo-ingress-nginx` of version `4.11.0` which was published to the local Helm repository on the Infra Setup steps.
+
+    You can find this new ServiceTemplate in the list of template with the command:
+    ```shell
+    PATH=$PATH:./bin kubectl -n hmc-system get servicetemplates
+    ```
+
+    Example of the output:
+    ```
+    NAME                        VALID
+    ...
+    demo-ingress-nginx-4.11.0   true <-- this is the installed template
+    ...
     ```
 
 2. Apply ServiceTemplate to cluster:
     ```shell
-    make apply-aws-test2-0.0.1-ingress
+    make apply-managed-cluster-aws-test2-0.0.1-ingress
     ```
     This applies the [0.0.1-ingress.yaml](managedClusters/aws/0.0.1-ingress.yaml) yaml template. For simplicity the yamls are a full `ManagedCluster` Object and not just a diff from the original cluster. The command output will show you a diff that explains that the only thing that actually has changed is the `serviceTemplate` key
 
 
-3. Show that ingress-nginx is installed in the managed cluster:
+3. Monitor how the ingress-nginx is installed in the managed cluster:
     ```shell
-    KUBECONFIG="kubeconfigs/hmc-system-aws-test2.kubeconfig" kubectl get pods -n ingress-nginx --watch
+    watch KUBECONFIG="kubeconfigs/hmc-system-aws-test2.kubeconfig" PATH=$PATH:./bin kubectl get pods -n ingress-nginx
+    ```
+
+    The final state should be similar to:
+    ```
+    NAME                                        READY   STATUS    RESTARTS   AGE
+    ingress-nginx-controller-86bd747cf9-ds56s   1/1     Running   0          34s
+    ```
+
+    You can also check the services status of the `ManagedCluster` of object in management cluster:
+
+    ```shell
+    PATH=$PATH:./bin kubectl -n hmc-system get managedcluster.hmc.mirantis.com hmc-system-aws-test2 -o yaml
+    ```
+
+    The output under the `status.services` should contain information about successfully deployed ingress nginx service:
+
+    ```
+    ...
+    status:
+      ...
+      services:
+      - clusterName: hmc-system-aws-test2
+        clusterNamespace: hmc-system
+        conditions:
+        ...
+        - lastTransitionTime: "2024-12-19T17:24:35Z"
+          message: Release ingress-nginx/ingress-nginx
+          reason: Managing
+          status: "True"
+          type: ingress-nginx.ingress-nginx/SveltosHelmReleaseReady
     ```
 
 
@@ -255,25 +412,91 @@ Be aware though that the cluster creation takes around 10-15mins, so depending o
 
 1. Install Kyverno ServiceTemplate in 2A:
     ```shell
-    make install-servicetemplate-demo-kyverno-3.2.6
+    make apply-servicetemplate-demo-kyverno-3.2.6
     ```
-    This will install a new servicetemplate which installs a standard installation of kyverno in a cluster. It has a clusterSelector configuration of the label `app.kubernetes.io/managed-by: Helm` which currently is the simplest way to match all clusters.
+    This will install a new [ServiceTemplate](./templates/service/demo-kyverno-3.2.6.yaml) which installs a standard installation of kyverno in a cluster.
+
+    You can find this new ServiceTemplate in the list of template with the command:
+    ```shell
+    PATH=$PATH:./bin kubectl -n hmc-system get servicetemplates
+    ```
+
+    Example of the output:
+    ```
+    NAME                        VALID
+    ...
+    demo-ingress-nginx-4.11.0   true 
+    demo-kyverno-3.2.6          true <-- this is the installed template
+    ...
+    ```
 
 2. Apply MultiClusterService to cluster:
     ```shell
     make apply-multiclusterservice-global-kyverno
     ```
 
-3. Show that kyverno is being installed in the two managed cluster:
+    This will install a `hmc.mirantis.com/v1alpha1/MultiClusterService` cluster-wide object to the management cluster. It has a clusterSelector configuration of the label `app.kubernetes.io/managed-by: Helm` which selects all `cluster.x-k8s.io/v1beta1/Cluster` objects with this label. Please, don't confuse `hmc.mirantis.com/v1alpha1/ManagedCluster` and `cluster.x-k8s.io/v1beta1/Cluster` types. First one - is the type of Project 2A objects, we deploy them to the management cluster and then, 2A operator creates various objects, including CAPI `cluster.x-k8s.io/v1beta1/Cluster`. `hmc.mirantis.com/v1alpha1/MultiClusterService` relies on `cluster.x-k8s.io/v1beta1/Cluster` labels. Currently, it's not possible to specify them in the `ManagedCluster` object configuration, there is an [issue](https://github.com/Mirantis/hmc/issues/801) on GitHub. But, to demonostrate the possibility of deploying service to multiple clusters without specifiying in each `ManagedCluster` object, we will use in this demo the `app.kubernetes.io/managed-by: Helm` label, which is automatically set to all `cluster.x-k8s.io/v1beta1/Cluster` objects by 2A.
+
+3. Monitor how the kyverno service is being installed in the two managed cluster:
     ```shell
-    KUBECONFIG="kubeconfigs/hmc-system-aws-test1.kubeconfig" kubectl get pods -n kyverno
+    watch KUBECONFIG="kubeconfigs/hmc-system-aws-test1.kubeconfig" kubectl get pods -n kyverno
     ```
 
     ```shell
-    KUBECONFIG="kubeconfigs/hmc-system-aws-test2.kubeconfig" kubectl get pods -n kyverno
+    watch KUBECONFIG="kubeconfigs/hmc-system-aws-test2.kubeconfig" kubectl get pods -n kyverno
     ```
 
     There might be a couple of seconds delay before that 2A and sveltos needs to start the installation of kyverno, give it at least 1 mins.
+
+    The final state for each cluster should be similar to:
+    ```
+    NAME                                             READY   STATUS    RESTARTS   AGE
+    kyverno-admission-controller-96c5d48b4-rqpdz     1/1     Running   0          47s
+    kyverno-background-controller-65f9fd5859-qfwqc   1/1     Running   0          47s
+    kyverno-cleanup-controller-848b4c579d-fc8s4      1/1     Running   0          47s
+    kyverno-reports-controller-6f59fb8cd6-9j4f7      1/1     Running   0          47s
+    ```    
+
+4. You can also check the deployment status for all clusters in the `MultiClusterService` object:
+    ```shell
+    PATH=$PATH:./bin kubectl get multiclusterservice global-kyverno -o yaml
+    ```
+
+    In the output you can find information about clusters where the service is deployed:
+    ```
+    apiVersion: hmc.mirantis.com/v1alpha1
+    kind: MultiClusterService
+    ...
+    status:
+      ...
+      services:
+        - clusterName: hmc-system-aws-test1
+          clusterNamespace: hmc-system
+          conditions:
+          - lastTransitionTime: "2025-01-03T14:12:33Z"
+            message: ""
+            reason: Provisioned
+            status: "True"
+            type: Helm
+          - lastTransitionTime: "2025-01-03T14:12:33Z"
+            message: Release kyverno/kyverno
+            reason: Managing
+            status: "True"
+            type: kyverno.kyverno/SveltosHelmReleaseReady
+        - clusterName: hmc-system-aws-test2
+          clusterNamespace: hmc-system
+          conditions:
+          - lastTransitionTime: "2025-01-03T14:12:33Z"
+            message: ""
+            reason: Provisioned
+            status: "True"
+            type: Helm
+          - lastTransitionTime: "2025-01-03T14:12:33Z"
+            message: Release kyverno/kyverno
+            reason: Managing
+            status: "True"
+            type: kyverno.kyverno/SveltosHelmReleaseReady
+    ```
 
 ## Demo 5: Approve ClusterTemplate & InfraCredentials for separate Namespace
 
@@ -282,14 +505,63 @@ Be aware though that the cluster creation takes around 10-15mins, so depending o
     make approve-clustertemplatechain-aws-standalone-cp-0.0.1
     ```
 
+    Check the status of the `hmc` AccessManagement object:
+    ```shell
+    PATH=$PATH:./bin kubectl -n hmc-system get AccessManagement hmc -o yaml
+    ```
+
+    In the status section you can find information about the clustertemplate that was approved to the target `blue` namespace:
+    ```
+    apiVersion: hmc.mirantis.com/v1alpha1
+    kind: AccessManagement
+    ...
+    status:
+      ...
+      current:
+      - clusterTemplateChains:
+        - demo-aws-standalone-cp-0.0.1
+        targetNamespaces:
+          list:
+          - blue
+    ```
+
 2. Approve the AWS credentials into the blue namspace
     ```shell
     make approve-credential-aws
     ```
 
-3. Show that the platform engineer only can see the approved clustertemplate and no other ones:
+    Check the status of the `hmc` AccessManagement object:
     ```shell
-    KUBECONFIG="certs/platform-engineer1/kubeconfig.yaml" kubectl get clustertemplates -n blue
+    PATH=$PATH:./bin kubectl -n hmc-system get AccessManagement hmc -o yaml
+    ```
+
+    In the status section you can find information about the clustertemplate that was approved to the target `blue` namespace:
+    ```
+    apiVersion: hmc.mirantis.com/v1alpha1
+    kind: AccessManagement
+    ...
+    status:
+      ...
+      current:
+      - credentials:
+        - aws-cluster-identity-cred
+        targetNamespaces:
+          list:
+          - blue
+    ```
+
+3. Show that the platform engineer only can see approved clustertemplate and credentials and no other ones:
+    ```shell
+    KUBECONFIG="certs/platform-engineer1/kubeconfig.yaml" PATH=$PATH:./bin kubectl get credentials,clustertemplates -n blue
+    ```
+
+    Output:
+    ```
+    NAME                                                    READY   DESCRIPTION
+    credential.hmc.mirantis.com/aws-cluster-identity-cred   true    AWS credentials
+
+    NAME                                                            VALID
+    clustertemplate.hmc.mirantis.com/demo-aws-standalone-cp-0.0.1   true
     ```
 
 ## Demo 6: Use approved ClusterTemplate in separate Namespace
@@ -298,8 +570,22 @@ This demo is currently broken in HMC 0.0.5 until [#818](https://github.com/Miran
 
 1. Create Cluster in blue namespace (this will be ran as platform engineer)
     ```shell
-    make apply-aws-dev1-0.0.1
+    make apply-managed-cluster-aws-dev1-0.0.1
     ```
+    This will create the object of type `ManagedCluster`, same as in [`Demo 1`](#demo-1-standalone-cluster-deployment) but in the `blue` namespace and using the approved and delivered `ClusterTemplate` to that namespace.
+
+3. Monitor the deployment of the cluster and wait when both be in Ready state:
+    For the first cluster:
+    ```shell
+    make watch-aws-dev1
+    ```
+
+    Example of the output of fully deployed first cluster:
+    ```
+    NAME                   READY   STATUS
+    blue-aws-dev1   True    ManagedCluster is ready
+    ```
+
 
 2. Get Kubeconfig for `aws-dev1`
     ```shell
@@ -309,6 +595,14 @@ This demo is currently broken in HMC 0.0.5 until [#818](https://github.com/Miran
 3. Access cluster
     ```shell
     KUBECONFIG="kubeconfigs/blue-aws-dev1.kubeconfig" kubectl get pods -A
+    ```
+
+    Example output:
+    ```
+    NAME                                  STATUS   ROLES           AGE   VERSION
+    blue-aws-dev1-cp-0             Ready    control-plane   58m   v1.31.2+k0s
+    blue-aws-dev1-md-xh4b5-h7qr5   Ready    <none>          49m   v1.31.2+k0s
+    blue-aws-dev1-md-xh4b5-hpmvk   Ready    <none>          49m   v1.31.2+k0s
     ```
 
 ## Demo 7: Test new clusterTemplate as 2A Admin, then approve them in separate Namespace
@@ -321,12 +615,7 @@ This demo is currently broken in HMC 0.0.5 until [#818](https://github.com/Miran
 
 ## Cleaning up
 
-To clean up the resources created on the public cloud providers, run the following command
-```shell
-   make cleanup-clusters
-```
-
 As running the whole 2a setup can be quite taxing on your hardware, run the following command to clean up everything (both the public cloud resources mentioned above but also all local containers):
 ```shell
-   make cleanup
+  make cleanup
 ```

--- a/managedClusters/aws/0.0.1-ingress.yaml
+++ b/managedClusters/aws/0.0.1-ingress.yaml
@@ -7,7 +7,7 @@ spec:
   template: demo-aws-standalone-cp-0.0.1
   credential: aws-cluster-identity-cred
   config:
-    region: us-east-2
+    region: ${AWS_REGION}
     publicIP: true
     controlPlaneNumber: 1
     workersNumber: 2

--- a/managedClusters/aws/0.0.1.yaml
+++ b/managedClusters/aws/0.0.1.yaml
@@ -7,7 +7,7 @@ spec:
   template: demo-aws-standalone-cp-0.0.1
   credential: aws-cluster-identity-cred
   config:
-    region: us-east-2
+    region: ${AWS_REGION}
     publicIP: true
     controlPlaneNumber: 1
     workersNumber: 2

--- a/managedClusters/aws/0.0.2-ingress.yaml
+++ b/managedClusters/aws/0.0.2-ingress.yaml
@@ -7,7 +7,7 @@ spec:
   template: demo-aws-standalone-cp-0.0.2
   credential: aws-cluster-identity-cred
   config:
-    region: us-east-2
+    region: ${AWS_REGION}
     publicIP: true
     controlPlaneNumber: 1
     workersNumber: 2

--- a/managedClusters/aws/0.0.2.yaml
+++ b/managedClusters/aws/0.0.2.yaml
@@ -7,7 +7,7 @@ spec:
   template: demo-aws-standalone-cp-0.0.2
   credential: aws-cluster-identity-cred
   config:
-    region: us-east-2
+    region: ${AWS_REGION}
     publicIP: true
     controlPlaneNumber: 1
     workersNumber: 2

--- a/templates/cluster/demo-aws-standalone-cp-0.0.1.yaml
+++ b/templates/cluster/demo-aws-standalone-cp-0.0.1.yaml
@@ -2,7 +2,7 @@ apiVersion: hmc.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
   name: demo-aws-standalone-cp-0.0.1
-  namespace: hmc-system
+  namespace: ${NAMESPACE}
 spec:
   helm:
     chartSpec:
@@ -25,7 +25,7 @@ apiVersion: hmc.mirantis.com/v1alpha1
 kind: ClusterTemplateChain
 metadata:
   name: demo-aws-standalone-cp-0.0.1
-  namespace: hmc-system
+  namespace: ${NAMESPACE}
 spec:
   supportedTemplates:
     - name: demo-aws-standalone-cp-0.0.1

--- a/templates/cluster/demo-aws-standalone-cp-0.0.1/values.yaml
+++ b/templates/cluster/demo-aws-standalone-cp-0.0.1/values.yaml
@@ -46,4 +46,4 @@ worker:
 
 # K0s parameters
 k0s:
-  version: v1.31.1+k0s.1
+  version: v1.31.2+k0s.0

--- a/templates/cluster/demo-aws-standalone-cp-0.0.2.yaml
+++ b/templates/cluster/demo-aws-standalone-cp-0.0.2.yaml
@@ -2,7 +2,7 @@ apiVersion: hmc.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
   name: demo-aws-standalone-cp-0.0.2
-  namespace: hmc-system
+  namespace: ${NAMESPACE}
 spec:
   helm:
     chartSpec:
@@ -25,7 +25,7 @@ apiVersion: hmc.mirantis.com/v1alpha1
 kind: ClusterTemplateChain
 metadata:
   name: demo-aws-standalone-cp-0.0.2
-  namespace: hmc-system
+  namespace: ${NAMESPACE}
 spec:
   supportedTemplates:
     - name: demo-aws-standalone-cp-0.0.1

--- a/templates/cluster/demo-aws-standalone-cp-0.0.2/values.yaml
+++ b/templates/cluster/demo-aws-standalone-cp-0.0.2/values.yaml
@@ -46,4 +46,4 @@ worker:
 
 # K0s parameters
 k0s:
-  version: v1.31.2+k0s.0
+  version: v1.31.3+k0s.0

--- a/templates/service/demo-ingress-nginx-4.11.0.yaml
+++ b/templates/service/demo-ingress-nginx-4.11.0.yaml
@@ -2,7 +2,7 @@ apiVersion: hmc.mirantis.com/v1alpha1
 kind: ServiceTemplate
 metadata:
   name: demo-ingress-nginx-4.11.0
-  namespace: hmc-system
+  namespace: ${NAMESPACE}
 spec:
   helm:
     chartSpec:
@@ -17,7 +17,7 @@ apiVersion: hmc.mirantis.com/v1alpha1
 kind: ServiceTemplateChain
 metadata:
   name: demo-ingress-nginx-4.11.0
-  namespace: hmc-system
+  namespace: ${NAMESPACE}
 spec:
   supportedTemplates:
     - name: demo-ingress-nginx-4.11.0

--- a/templates/service/demo-ingress-nginx-4.11.3.yaml
+++ b/templates/service/demo-ingress-nginx-4.11.3.yaml
@@ -2,7 +2,7 @@ apiVersion: hmc.mirantis.com/v1alpha1
 kind: ServiceTemplate
 metadata:
   name: demo-ingress-nginx-4.11.3
-  namespace: hmc-system
+  namespace: ${NAMESPACE}
 spec:
   helm:
     chartSpec:
@@ -17,7 +17,7 @@ apiVersion: hmc.mirantis.com/v1alpha1
 kind: ServiceTemplateChain
 metadata:
   name: demo-ingress-nginx-4.11.3
-  namespace: hmc-system
+  namespace: ${NAMESPACE}
 spec:
   supportedTemplates:
     - name: demo-ingress-nginx-4.11.0

--- a/templates/service/demo-kyverno-3.2.6.yaml
+++ b/templates/service/demo-kyverno-3.2.6.yaml
@@ -2,7 +2,7 @@ apiVersion: hmc.mirantis.com/v1alpha1
 kind: ServiceTemplate
 metadata:
   name: demo-kyverno-3.2.6
-  namespace: hmc-system
+  namespace: ${NAMESPACE}
 spec:
   helm:
     chartSpec:
@@ -17,7 +17,7 @@ apiVersion: hmc.mirantis.com/v1alpha1
 kind: ServiceTemplateChain
 metadata:
   name: demo-kyverno-3.2.6
-  namespace: hmc-system
+  namespace: ${NAMESPACE}
 spec:
   supportedTemplates:
     - name: demo-kyverno-3.2.6


### PR DESCRIPTION
- Updated k0s version in ClusterTemplates due to the bug in v1.31.1 that blocks the cluster upgrade
- Added bash as a default CL
- Makefile cleanup and refactoring
- Remove old kind config before creating a new cluster
- Added the helm repo readiness wait loop before pushing helm charts
- Added possibility to change the AWS region for the demo
- Extended docs with examples and notes